### PR TITLE
Add support for upgrade of cert manager #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,30 @@ To use custom storage classes for cassandra statefulsets, you can populate the `
 - anthos-vsphere-csi
 *Note: If you face any issues with any of the provisioners, please create a github issue in this repository*
 
+#### To update cert-manager
+
+To update cert-manager, follow these steps:
+
+1. Specify the version in the vars.yaml file:
+    Modify the cert_manager_version variable in the vars/vars.yaml file to the desired version. For example:
+```
+cert_manager_version: v1.14.0
+```
+
+Run the Ansible playbook:
+Execute the Ansible playbook which includes the logic to check the current version of cert-manager, compare it with the specified version, and update if necessary.
+```
+ansible-playbook playbook.yaml -e @vars/vars.yaml --tags "cert-manager"
+```
+The playbook will:
+
+- Check the currently installed version of cert-manager.
+- Compare it with the version specified in the vars.yaml file.
+- If the versions differ, the playbook will download and apply the new cert-manager manifest.
+- If the versions are the same and cert-manager is running, no action will be taken.
+- If cert-manager is not installed, the playbook will install it using the specified version.
+
+
 ## Limitations
 * Refer [link](https://cloud.google.com/apigee/docs/hybrid/preview/helm-install#limitations)
 

--- a/roles/cert-manager/tasks/main.yml
+++ b/roles/cert-manager/tasks/main.yml
@@ -13,10 +13,20 @@
 # limitations under the License.
 ---
 # tasks file for cert-manager
+# tasks file for cert-manager
 - name: Certificates directory exists
   file:
     path: "{{ setup_path }}"
     state: directory
+
+- name: Check if cert-manager is installed
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    namespace: cert-manager
+    label_selectors:
+      - "app.kubernetes.io/instance=cert-manager"
+  register: cert_manager_deployments
+  ignore_errors: true
 
 - name: Install cert manager
   block:
@@ -27,9 +37,9 @@
 
     - name: Apply cert-manager manifest to the cluster.
       kubernetes.core.k8s:
-        state: "{{cert_manager_status}}"
+        state: "{{ cert_manager_status }}"
         src: "{{ setup_path }}/cert-manager.yaml"
-  when: "install_cert_manager"
+  when: "install_cert_manager and cert_manager_deployments.resources | length == 0"
 
 - name: Wait for cert-manager to be up.
   kubernetes.core.k8s_info:

--- a/roles/cert-manager/tasks/main.yml
+++ b/roles/cert-manager/tasks/main.yml
@@ -28,18 +28,24 @@
   register: cert_manager_deployments
   ignore_errors: true
 
-- name: Install cert manager
+- name: Get the currently running version of cert-manager
+  shell: "kubectl get deployment -n cert-manager -l app.kubernetes.io/instance=cert-manager -o jsonpath='{.items[0].metadata.labels.app\\.kubernetes\\.io/version}'"
+  register: running_cert_manager_version
+  when: "cert_manager_deployments.resources | length > 0"
+
+- name: Install or upgrade cert-manager
   block:
     - name: Download cert-manager
       uri:
-        url: https://github.com/jetstack/cert-manager/releases/download/{{ cert_manager_version }}/cert-manager.yaml
+        url: "https://github.com/jetstack/cert-manager/releases/download/{{ cert_manager_version }}/cert-manager.yaml"
         dest: "{{ setup_path }}/cert-manager.yaml"
+      when: "cert_manager_deployments.resources | length == 0 or running_cert_manager_version.stdout != cert_manager_version"
 
     - name: Apply cert-manager manifest to the cluster.
       kubernetes.core.k8s:
-        state: "{{ cert_manager_status }}"
+        state: "present"
         src: "{{ setup_path }}/cert-manager.yaml"
-  when: "install_cert_manager and cert_manager_deployments.resources | length == 0"
+  when: "cert_manager_deployments.resources | length == 0 or running_cert_manager_version.stdout != cert_manager_version"
 
 - name: Wait for cert-manager to be up.
   kubernetes.core.k8s_info:

--- a/roles/validate-api-calls/files/deploy_api.py
+++ b/roles/validate-api-calls/files/deploy_api.py
@@ -266,4 +266,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-    

--- a/roles/validate-api-calls/files/deploy_api.py
+++ b/roles/validate-api-calls/files/deploy_api.py
@@ -18,6 +18,7 @@ import argparse
 import os
 import sys
 from time import sleep
+
 import requests
 
 
@@ -34,16 +35,15 @@ class Apigee:
         self.baseurl = f"{base_url}/organizations/{org}"
         self.apigee_type = apigee_type
         self.auth_type = auth_type
-        self.auth_header = self._generate_auth_header(access_token)
-
-    def _generate_auth_header(self, access_token):
-        token = self.get_access_token(access_token)
-        return {
-            "Authorization": f"Bearer {token}" if self.auth_type == "oauth" else f"Basic {token}"
+        access_token = self.get_access_token(access_token)
+        self.auth_header = {
+            "Authorization": "Bearer {}".format(access_token)
+            if self.auth_type == "oauth"
+            else "Basic {}".format(access_token)  # noqa
         }
 
     def is_token_valid(self, token):
-        url = f"https://www.googleapis.com/oauth2/v1/tokeninfo?access_token={token}"
+        url = f"https://www.googleapis.com/oauth2/v1/tokeninfo?access_token={token}"  # noqa
         response = requests.get(url)
         if response.status_code == 200:
             print(f"Token Validated for user {response.json()['email']}")
@@ -51,111 +51,187 @@ class Apigee:
         return False
 
     def get_access_token(self, access_token):
-        if access_token and self.is_token_valid(access_token):
-            return access_token
-        print('Please run "export APIGEE_ACCESS_TOKEN=$(gcloud auth print-access-token)" first !!')
-        sys.exit(1)
+        token = access_token
+        if token is not None:
+            if self.apigee_type == "x":
+                if self.is_token_valid(token):
+                    return token
+                else:
+                    print(
+                        'please run "export APIGEE_ACCESS_TOKEN=$(gcloud auth print-access-token)" first !! '  # noqa type: ignore
+                    )
+                    sys.exit(1)
+            else:
+                return token
+        else:
+            if self.apigee_type == "x":
+                print(
+                    'please run "export APIGEE_ACCESS_TOKEN=$(gcloud auth print-access-token)" first !! '  # noqa
+                )
+            else:
+                print("please export APIGEE_OPDK_ACCESS_TOKEN")
+            sys.exit(1)
+
+    def set_auth_header(self):
+        access_token = self.get_access_token()
+        self.auth_header = {
+            "Authorization": "Bearer {}".format(access_token)
+            if self.auth_type == "oauth"
+            else "Basic {}".format(access_token)
+        }
 
     def get_api(self, api_name):
         url = f"{self.baseurl}/apis/{api_name}"
-        response = requests.get(url, headers=self.auth_header)
+        headers = self.auth_header.copy()
+        response = requests.request("GET", url, headers=headers)
         if response.status_code == 200:
             revision = response.json().get('revision', ['1'])
             return True, revision
-        return False, None
+        else:
+            return False, None
 
     def create_api(self, api_name, proxy_bundle_path):
-        url = f"{self.baseurl}/apis?action=import&name={api_name}&validate=true"
+        url = f"{self.baseurl}/apis?action=import&name={api_name}&validate=true"  # noqa
         proxy_bundle_name = os.path.basename(proxy_bundle_path)
-        with open(proxy_bundle_path, "rb") as proxy_bundle_file:
-            files = [("data", (proxy_bundle_name, proxy_bundle_file, "application/zip"))]
-            response = requests.post(url, headers=self.auth_header, files=files)
+        files = [
+            (
+                "data",
+                (proxy_bundle_name, open(proxy_bundle_path, "rb"), "application/zip"),  # noqa
+            )
+        ]
+        headers = self.auth_header.copy()
+        response = requests.request(
+            "POST", url, headers=headers, data={}, files=files
+        )
         if response.status_code == 200:
             revision = response.json().get('revision', "1")
             return True, revision
         print(response.text)
         return False, None
 
-    def get_api_revisions_deployment(self, env, api_name, api_rev):
-        url = f"{self.baseurl}/environments/{env}/apis/{api_name}/revisions/{api_rev}/deployments"
-        response = requests.get(url, headers=self.auth_header)
+    def get_api_revisions_deployment(self, env, api_name, api_rev):  # noqa
+        url = (
+            url
+        ) = f"{self.baseurl}/environments/{env}/apis/{api_name}/revisions/{api_rev}/deployments"  # noqa
+        headers = self.auth_header.copy()
+        response = requests.request("GET", url, headers=headers, data={})
         if response.status_code == 200:
-            api_deployment_status = response.json().get("state", "")
-            if (self.apigee_type == "x" and api_deployment_status == "READY") or \
-               (self.apigee_type == "opdk" and api_deployment_status == "deployed"):
-                return True
-            print(f"API {api_name} is in Status: {api_deployment_status} !")
+            resp = response.json()
+            api_deployment_status = resp.get("state", "")
+            if self.apigee_type == "x":
+                if api_deployment_status == "READY":
+                    return True
+            if self.apigee_type == "opdk":
+                if api_deployment_status == "deployed":
+                    return True
+            print(f"API {api_name} is in Status: {api_deployment_status} !")  # noqa
+            return False
         else:
             print(response.text)
-        return False
+            return False
 
     def deploy_api(self, env, api_name, api_rev):
-        url = f"{self.baseurl}/environments/{env}/apis/{api_name}/revisions/{api_rev}/deployments?override=true"
-        response = requests.post(url, headers=self.auth_header)
+        url = (
+            url
+        ) = f"{self.baseurl}/environments/{env}/apis/{api_name}/revisions/{api_rev}/deployments?override=true"  # noqa
+        headers = self.auth_header.copy()
+        response = requests.request("POST", url, headers=headers, data={})
         if response.status_code == 200:
             return True
-        if "already deployed" in response.json().get("error", {}).get("message", ""):
-            print(f"Proxy {api_name} is already Deployed")
-            return True
-        print(response.text)
-        return False
+        else:
+            resp = response.json()
+            if "already deployed" in resp["error"]["message"]:
+                print("Proxy {} is already Deployed".format(api_name))
+                return True
+            print(response.text)
+            return False
 
-    def deploy_api_bundle(self, env, api_name, proxy_bundle_path, api_force_redeploy=False):
+    def deploy_api_bundle(self, env, api_name, proxy_bundle_path, api_force_redeploy=False):  # noqa
         api_deployment_retry = 60
         api_deployment_sleep = 5
         api_deployment_retry_count = 0
-
+        api_exists = False
         get_api_status, api_revs = self.get_api(api_name)
-        api_rev = api_revs[-1] if get_api_status else None
-
         if get_api_status:
-            print(f"Proxy with name {api_name} with revision {api_rev} already exists in Apigee Org {self.org}")
+            api_exists = True
+            api_rev = api_revs[-1]
+            print(
+                f"Proxy with name {api_name} with revision {api_rev} already exists in Apigee Org {self.org}"  # noqa
+            )
             if api_force_redeploy:
-                api_rev = None
-
-        if not api_rev:
+                api_exists = False
+        if not api_exists:
             api_created, api_rev = self.create_api(api_name, proxy_bundle_path)
-            if not api_created:
-                print(f"ERROR : Proxy {api_name} import failed !!!")
+            if api_created:
+                print(
+                    f"Proxy has been imported with name {api_name} in Apigee Org {self.org}"  # noqa
+                )
+                api_exists = True
+            else:
+                print(f"ERROR : Proxy {api_name} import failed !!! ")
                 return False
-            print(f"Proxy has been imported with name {api_name} in Apigee Org {self.org}")
-
-        if self.get_api_revisions_deployment(env, api_name, api_rev):
-            print(f"INFO : Proxy {api_name} already active in {env} in Apigee Org {self.org}!")
-            return True
-
-        if self.deploy_api(env, api_name, api_rev):
-            print(f"Proxy with name {api_name} has been deployed to {env} in Apigee Org {self.org}")
-            while api_deployment_retry_count < api_deployment_retry:
-                if self.get_api_revisions_deployment(env, api_name, api_rev):
-                    print(f"Proxy {api_name} active in runtime after {api_deployment_retry_count * api_deployment_sleep} seconds")
-                    return True
-                print(f"Checking API deployment status in {api_deployment_sleep} seconds")
-                sleep(api_deployment_sleep)
-                api_deployment_retry_count += 1
-        print(f"ERROR : Proxy deployment to {env} in Apigee Org {self.org} Failed !!")
-        return False
+        if api_exists:
+            if self.get_api_revisions_deployment(
+                        env, api_name, api_rev
+                    ):
+                print(f"INFO : Proxy {api_name} already active in to {env} in Apigee Org {self.org} !")  # noqa
+                return True
+            else:
+                if self.deploy_api(env, api_name, api_rev):
+                    print(
+                        f"Proxy with name {api_name} has been deployed  to {env} in Apigee Org {self.org}"  # noqa
+                    )
+                    while api_deployment_retry_count < api_deployment_retry:
+                        if self.get_api_revisions_deployment(
+                            env, api_name, api_rev
+                        ):
+                            print(
+                                f"Proxy {api_name} active in runtime after {api_deployment_retry_count*api_deployment_sleep} seconds "  # noqa
+                            )
+                            return True
+                        else:
+                            print(
+                                f"Checking API deployment status in {api_deployment_sleep} seconds"  # noqa
+                            )
+                            sleep(api_deployment_sleep)
+                            api_deployment_retry_count += 1
+                else:
+                    print(
+                        f"ERROR : Proxy deployment  to {env} in Apigee Org {self.org} Failed !!"  # noqa
+                    )
+                    return False
 
     def list_apis(self, api_type):
         url = f"{self.baseurl}/{api_type}"
-        response = requests.get(url, headers=self.auth_header)
+        headers = self.auth_header.copy()
+        response = requests.get(url, headers=headers)
         if response.status_code == 200:
             if self.apigee_type == "x":
-                proxies = response.json().get("proxies" if api_type == "apis" else "sharedFlows", [])
-                return [p["name"] for p in proxies]
+                if len(response.json()) == 0:
+                    return []
+                return [
+                    p["name"]
+                    for p in response.json()[
+                        "proxies" if api_type == "apis" else "sharedFlows"
+                    ]
+                ]  # noqa
             return response.json()
-        return []
+        else:
+            return []
 
     def list_api_revisions(self, api_type, api_name):
         url = f"{self.baseurl}/{api_type}/{api_name}/revisions"
-        response = requests.get(url, headers=self.auth_header)
+        headers = self.auth_header.copy()
+        response = requests.get(url, headers=headers)
         if response.status_code == 200:
             return response.json()
-        return []
+        else:
+            return []
 
-    def fetch_api_revision(self, api_type, api_name, revision, export_dir):
-        url = f"{self.baseurl}/{api_type}/{api_name}/revisions/{revision}?format=bundle"
-        response = requests.get(url, headers=self.auth_header, stream=True)
+    def fetch_api_revision(self, api_type, api_name, revision, export_dir):  # noqa
+        url = f"{self.baseurl}/{api_type}/{api_name}/revisions/{revision}?format=bundle"  # noqa
+        headers = self.auth_header.copy()
+        response = requests.get(url, headers=headers, stream=True)
         if response.status_code == 200:
             self.write_proxy_bundle(export_dir, api_name, response.raw)
             return True
@@ -163,24 +239,22 @@ class Apigee:
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Deploy Apigee API proxy bundle')
+    parser = argparse.ArgumentParser(description='Deploy Apigee API proxy bundle')  # noqa
     parser.add_argument('--project_id', help='GCP Project ID')
     parser.add_argument('--env', help='Apigee Environment Name')
     parser.add_argument('--api_name', help='Apigee API Name')
-    parser.add_argument('--api_bundle_path', help='Apigee API Proxy bundle path')
+    parser.add_argument('--api_bundle_path', help='Apigee API Proxy bundle path')  # noqa
     parser.add_argument('--access_token', help='GCP OAuth Access Token')
-    parser.add_argument('--api_redeploy', help='Redploy API', action="store_true")
+    parser.add_argument('--api_redeploy', help='Redploy API',action="store_true")  # noqa
     args = parser.parse_args()
-
-    target_apigee = Apigee(
+    TargetApigee = Apigee(
         "x",
         "https://apigee.googleapis.com/v1",
         "oauth",
         args.project_id,
         args.access_token,
     )
-
-    if not target_apigee.deploy_api_bundle(
+    if not TargetApigee.deploy_api_bundle(
         args.env,
         args.api_name,
         args.api_bundle_path,

--- a/roles/validate-api-calls/files/deploy_api.py
+++ b/roles/validate-api-calls/files/deploy_api.py
@@ -266,3 +266,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+    


### PR DESCRIPTION
Fixes #34 

> It's a good idea to open an issue first for discussion. [Issue](https://github.com/apigee/ansible-apigee-hybrid-accelerator/issues/34)

- [x] Tests pass _(cannot run E2E)_
- [x] Appropriate changes to README are included in PR

---

This pull request introduces an update mechanism for cert-manager within the Ansible playbook and updates the documentation to reflect these changes. The most important changes include adding a section to the `README.md` for updating cert-manager and modifying the Ansible tasks to check for the current version before updating.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R197-R220): Added a section detailing the steps to update cert-manager, including specifying the version in `vars.yaml` and running the Ansible playbook.

Ansible playbook enhancements:

* [`roles/cert-manager/tasks/main.yml`](diffhunk://#diff-d5f4eec518174350af45f902cb1a97ed86844eba9fb745ae261f0bcf05059390R16-R48): Added tasks to check if cert-manager is installed, retrieve the currently running version, and conditionally download and apply the cert-manager manifest only if an update is needed.